### PR TITLE
Tmap local_map 중복정의 문제 해결

### DIFF
--- a/react-are/src/search/Tmap.jsx
+++ b/react-are/src/search/Tmap.jsx
@@ -163,7 +163,7 @@ function TMap() {
 			alert("onError");
 		  }
 
-		const local_map = document.querySelector("div.local_box")
+		var local_map = document.querySelector("div.local_box")
 	  if (local_map) {
 		local_map.addEventListener("click", (e) => {
 			let active = document.querySelector("div.active")


### PR DESCRIPTION
166번째 줄
var local_map = document.querySelector("div.local_box")

기존 const 에서 전역변수 var로 선언해주니 중복 정의 오류가 해결되었다.